### PR TITLE
Add NPM_TOKEN env for semantic-release and document required secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,5 +40,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release

--- a/README.md
+++ b/README.md
@@ -37,4 +37,4 @@ Required setup:
 - In npm package settings, add this GitHub repository/workflow as a trusted publisher.
 - Keep `id-token: write` permission in `.github/workflows/release.yml`.
 - `GITHUB_TOKEN` is provided automatically by GitHub Actions.
-- `NPM_TOKEN` is **not required** when trusted publishing is configured correctly.
+- Add `NPM_TOKEN` repository secret for semantic-release npm authentication (kept alongside trusted publishing settings).


### PR DESCRIPTION
### Motivation
- Ensure `semantic-release` can authenticate to npm from GitHub Actions by providing an `NPM_TOKEN` and `NODE_AUTH_TOKEN` to the release job when necessary.

### Description
- Add `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` and `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the `Release` step in `.github/workflows/release.yml` while keeping `GITHUB_TOKEN` and `NPM_CONFIG_PROVENANCE` unchanged.
- Update `README.md` to instruct adding an `NPM_TOKEN` repository secret for `semantic-release` npm authentication (replacing the previous note that `NPM_TOKEN` was not required).

### Testing
- No automated tests were executed as part of this workflow/documentation change; the existing CI steps (`npm ci`, `npm test`, `npm run build`) in the workflow were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae9660aee08328811e9b9d91d221a9)