### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jonime/ts-zxcvbn/security/code-scanning/1](https://github.com/jonime/ts-zxcvbn/security/code-scanning/1)

To fix the problem, explicitly define minimal `GITHUB_TOKEN` permissions in the workflow. Since this CI job only needs to read the repository contents (for checkout) and does not perform any writes, we can safely set `contents: read`. This can be done at the workflow (top) level so it applies to all jobs that do not override it.

The best way to fix this without changing functionality is:

- Add a `permissions:` block near the top of `.github/workflows/ci.yml`, at the same indentation as `name:` and `on:`.
- Set `contents: read` in that block.
- Do not modify any existing jobs or steps.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block. No imports or additional definitions are needed; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
