### PR TITLE
refactor: clean up decaffeination artifacts

### DIFF
--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -59,22 +59,20 @@ const feedback = {
         return feedback.get_dictionary_match_feedback(match, is_sole_match);
 
       case 'spatial':
-        var warning =
-          match.turns === 1
-            ? Warning.SpatialStraightRow
-            : Warning.SpatialShortKeyboardPattern;
         return {
-          warning,
+          warning:
+            match.turns === 1
+              ? Warning.SpatialStraightRow
+              : Warning.SpatialShortKeyboardPattern,
           suggestions: ['Use a longer keyboard pattern with more turns'],
         };
 
       case 'repeat':
-        warning =
-          match.base_token.length === 1
-            ? Warning.RepeatCharacter
-            : Warning.RepeatPattern;
         return {
-          warning,
+          warning:
+            match.base_token.length === 1
+              ? Warning.RepeatCharacter
+              : Warning.RepeatPattern,
           suggestions: ['Avoid repeated words and characters'],
         };
 
@@ -108,19 +106,19 @@ const feedback = {
     match: DictionaryMatch,
     is_sole_match: boolean
   ): { warning: Warning; suggestions: string[] } {
-    const warning = ((): Warning | null => {
-      switch (match.dictionary_name) {
-        case 'passwords':
-          if (is_sole_match && !match.l33t && !match.reversed) {
-            return Warning.CommonPassword;
-          } else if (match.guesses_log10 <= 5) {
-            return Warning.SimilarToCommonPassword;
-          }
-          return null;
-        case 'names':
-          return Warning.Name;
-      }
-    })();
+    let warning: Warning | null = null;
+    switch (match.dictionary_name) {
+      case 'passwords':
+        if (is_sole_match && !match.l33t && !match.reversed) {
+          warning = Warning.CommonPassword;
+        } else if (match.guesses_log10 <= 5) {
+          warning = Warning.SimilarToCommonPassword;
+        }
+        break;
+      case 'names':
+        warning = Warning.Name;
+        break;
+    }
 
     const suggestions = [];
     const word = match.token;

--- a/src/matching.js
+++ b/src/matching.js
@@ -1,4 +1,3 @@
-let name;
 import frequency_lists from './frequency_lists.js';
 import adjacency_graphs from './adjacency_graphs.js';
 import scoring from './scoring.js';
@@ -14,7 +13,7 @@ const build_ranked_dict = function (ordered_list) {
 };
 
 const RANKED_DICTIONARIES = {};
-for (name in frequency_lists) {
+for (const name of Object.keys(frequency_lists)) {
   const lst = frequency_lists[name];
   RANKED_DICTIONARIES[name] = build_ranked_dict(lst);
 }
@@ -74,15 +73,7 @@ const DATE_SPLITS = {
 
 const matching = {
   empty(obj) {
-    return (
-      (() => {
-        const result = [];
-        for (let k in obj) {
-          result.push(k);
-        }
-        return result;
-      })().length === 0
-    );
+    return Object.keys(obj).length === 0;
   },
   extend(lst, lst2) {
     return lst.push.apply(lst, lst2);
@@ -134,18 +125,10 @@ const matching = {
     const matches = [];
     const len = password.length;
     const password_lower = password.toLowerCase();
-    for (let dictionary_name in _ranked_dictionaries) {
+    for (const dictionary_name of Object.keys(_ranked_dictionaries)) {
       const ranked_dict = _ranked_dictionaries[dictionary_name];
-      for (
-        let i = 0, end = len, asc = 0 <= end;
-        asc ? i < end : i > end;
-        asc ? i++ : i--
-      ) {
-        for (
-          let j = i, end1 = len, asc1 = i <= end1;
-          asc1 ? j < end1 : j > end1;
-          asc1 ? j++ : j--
-        ) {
+      for (let i = 0; i < len; i++) {
+        for (let j = i; j < len; j++) {
           if (password_lower.slice(i, +j + 1 || undefined) in ranked_dict) {
             const word = password_lower.slice(i, +j + 1 || undefined);
             const rank = ranked_dict[word];
@@ -219,38 +202,16 @@ const matching = {
 
   // returns the list of possible 1337 replacement dictionaries for a given password
   enumerate_l33t_subs(table) {
-    let k;
-    const keys = (() => {
-      const result = [];
-      for (k in table) {
-        result.push(k);
-      }
-      return result;
-    })();
+    const keys = Object.keys(table);
     let subs = [[]];
 
     const dedup = function (subs) {
-      let v, k;
       const deduped = [];
       const members = {};
-      for (var sub of Array.from(subs)) {
-        var assoc = (() => {
-          const result1 = [];
-          for (v = 0; v < sub.length; v++) {
-            k = sub[v];
-            result1.push([k, v]);
-          }
-          return result1;
-        })();
+      for (const sub of subs) {
+        const assoc = sub.map((k, v) => [k, v]);
         assoc.sort();
-        const label = (() => {
-          const result2 = [];
-          for (v = 0; v < assoc.length; v++) {
-            k = assoc[v];
-            result2.push(k + ',' + v);
-          }
-          return result2;
-        })().join('-');
+        const label = assoc.map(([k, v]) => `${k},${v}`).join('-');
         if (!(label in members)) {
           members[label] = true;
           deduped.push(sub);
@@ -259,7 +220,7 @@ const matching = {
       return deduped;
     };
 
-    var helper = function (keys) {
+    const helper = function (keys) {
       if (!keys.length) {
         return;
       }
@@ -269,11 +230,7 @@ const matching = {
       for (let l33t_chr of Array.from(table[first_key])) {
         for (let sub of Array.from(subs)) {
           let dup_l33t_index = -1;
-          for (
-            let i = 0, end = sub.length, asc = 0 <= end;
-            asc ? i < end : i > end;
-            asc ? i++ : i--
-          ) {
+          for (let i = 0; i < sub.length; i++) {
             if (sub[i][0] === l33t_chr) {
               dup_l33t_index = i;
               break;
@@ -332,8 +289,8 @@ const matching = {
         if (token.toLowerCase() === match.matched_word) {
           continue; // only return the matches that contain an actual substitution
         }
-        var match_sub = {}; // subset of mappings in sub that are in use for this match
-        for (let subbed_chr in sub) {
+        const match_sub = {}; // subset of mappings in sub that are in use for this match
+        for (const subbed_chr of Object.keys(sub)) {
           const chr = sub[subbed_chr];
           if (token.indexOf(subbed_chr) !== -1) {
             match_sub[subbed_chr] = chr;
@@ -342,14 +299,9 @@ const matching = {
         match.l33t = true;
         match.token = token;
         match.sub = match_sub;
-        match.sub_display = (() => {
-          const result = [];
-          for (let k in match_sub) {
-            const v = match_sub[k];
-            result.push(`${k} -> ${v}`);
-          }
-          return result;
-        })().join(', ');
+        match.sub_display = Object.entries(match_sub)
+          .map(([k, v]) => `${k} -> ${v}`)
+          .join(', ');
         matches.push(match);
       }
     }
@@ -389,7 +341,7 @@ const matching = {
     const matches = [];
     let i = 0;
     while (i < password.length - 1) {
-      var shifted_count;
+      let shifted_count;
       let j = i + 1;
       let last_direction = null;
       let turns = 0;
@@ -470,7 +422,7 @@ const matching = {
     const lazy_anchored = /^(.+?)\1+$/;
     let lastIndex = 0;
     while (lastIndex < password.length) {
-      var base_token, match;
+      let base_token, match;
       greedy.lastIndex = lazy.lastIndex = lastIndex;
       const greedy_match = greedy.exec(password);
       const lazy_match = lazy.exec(password);
@@ -570,15 +522,11 @@ const matching = {
       }
     };
 
-    var result = [];
+    const result = [];
     let i = 0;
     let last_delta = null;
 
-    for (
-      let k = 1, end = password.length, asc = 1 <= end;
-      asc ? k < end : k > end;
-      asc ? k++ : k--
-    ) {
+    for (let k = 1; k < password.length; k++) {
       const delta = password.charCodeAt(k) - password.charCodeAt(k - 1);
       if (last_delta == null) {
         last_delta = delta;
@@ -604,10 +552,10 @@ const matching = {
       _regexen = REGEXEN;
     }
     const matches = [];
-    for (name in _regexen) {
-      var rx_match;
+    for (const name of Object.keys(_regexen)) {
       const regex = _regexen[name];
       regex.lastIndex = 0; // keeps regex_match stateless
+      let rx_match;
       while ((rx_match = regex.exec(password))) {
         const token = rx_match[0];
         matches.push({
@@ -647,8 +595,6 @@ const matching = {
     // this uses a ^...$ regex against every substring of the password -- less performant but leads
     // to every possible date match.
     let dmy, i, j, token;
-    let asc, end;
-    let asc2, end2;
     const matches = [];
     const maybe_date_no_separator = /^\d{4,8}$/;
     const maybe_date_with_separator = new RegExp(`\
@@ -662,17 +608,8 @@ $\
 `);
 
     // dates without separators are between length 4 '1191' and 8 '11111991'
-    for (
-      i = 0, end = password.length - 4, asc = 0 <= end;
-      asc ? i <= end : i >= end;
-      asc ? i++ : i--
-    ) {
-      var asc1, end1, start;
-      for (
-        start = i + 3, j = start, end1 = i + 7, asc1 = start <= end1;
-        asc1 ? j <= end1 : j >= end1;
-        asc1 ? j++ : j--
-      ) {
+    for (i = 0; i <= password.length - 4; i++) {
+      for (j = i + 3; j <= i + 7; j++) {
         if (j >= password.length) {
           break;
         }
@@ -724,17 +661,8 @@ $\
     }
 
     // dates with separators are between length 6 '1/1/91' and 10 '11/11/1991'
-    for (
-      i = 0, end2 = password.length - 6, asc2 = 0 <= end2;
-      asc2 ? i <= end2 : i >= end2;
-      asc2 ? i++ : i--
-    ) {
-      var asc3, end3, start1;
-      for (
-        start1 = i + 5, j = start1, end3 = i + 9, asc3 = start1 <= end3;
-        asc3 ? j <= end3 : j >= end3;
-        asc3 ? j++ : j--
-      ) {
+    for (i = 0; i <= password.length - 6; i++) {
+      for (j = i + 5; j <= i + 9; j++) {
         if (j >= password.length) {
           break;
         }

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,22 +1,14 @@
-let k, v;
 import adjacency_graphs from './adjacency_graphs.js';
 
 // on qwerty, 'g' has degree 6, being adjacent to 'ftyhbv'. '\' has degree 1.
 // this calculates the average over all keys.
 const calc_average_degree = function (graph) {
   let average = 0;
-  for (let key in graph) {
+  for (const key of Object.keys(graph)) {
     const neighbors = graph[key];
     average += Array.from(neighbors).filter((n) => n).length;
   }
-  average /= (() => {
-    const result = [];
-    for (k in graph) {
-      v = graph[k];
-      result.push(k);
-    }
-    return result;
-  })().length;
+  average /= Object.keys(graph).length;
   return average;
 };
 
@@ -35,11 +27,7 @@ const scoring = {
       return 1;
     }
     let r = 1;
-    for (
-      let d = 1, end = k, asc = 1 <= end;
-      asc ? d <= end : d >= end;
-      asc ? d++ : d--
-    ) {
+    for (let d = 1; d <= k; d++) {
       r *= n;
       r /= d;
       n -= 1;
@@ -60,11 +48,7 @@ const scoring = {
       return 1;
     }
     let f = 1;
-    for (
-      let i = 2, end = n, asc = 2 <= end;
-      asc ? i <= end : i >= end;
-      asc ? i++ : i--
-    ) {
+    for (let i = 2; i <= n; i++) {
       f *= i;
     }
     return f;
@@ -104,28 +88,15 @@ const scoring = {
   // ------------------------------------------------------------------------------
 
   most_guessable_match_sequence(password, matches, _exclude_additive) {
-    let guesses, m;
-    let asc4, end4;
-    let _;
+    let k;
     if (_exclude_additive == null) {
       _exclude_additive = false;
     }
     const n = password.length;
 
     // partition matches into sublists according to ending index j
-    const matches_by_j = (() => {
-      let asc, end;
-      const result = [];
-      for (
-        _ = 0, end = n, asc = 0 <= end;
-        asc ? _ < end : _ > end;
-        asc ? _++ : _--
-      ) {
-        result.push([]);
-      }
-      return result;
-    })();
-    for (m of Array.from(matches)) {
+    const matches_by_j = Array.from({ length: n }, () => []);
+    for (const m of Array.from(matches)) {
       matches_by_j[m.j].push(m);
     }
     // small detail: for deterministic output, sort each sublist by i.
@@ -138,47 +109,14 @@ const scoring = {
       // password prefix up to k, inclusive.
       // if there is no length-l sequence that scores better (fewer guesses) than
       // a shorter match sequence spanning the same prefix, optimal.m[k][l] is undefined.
-      m: (() => {
-        let asc1, end1;
-        const result1 = [];
-        for (
-          _ = 0, end1 = n, asc1 = 0 <= end1;
-          asc1 ? _ < end1 : _ > end1;
-          asc1 ? _++ : _--
-        ) {
-          result1.push({});
-        }
-        return result1;
-      })(),
+      m: Array.from({ length: n }, () => ({})),
 
       // same structure as optimal.m -- holds the product term Prod(m.guesses for m in sequence).
       // optimal.pi allows for fast (non-looping) updates to the minimization function.
-      pi: (() => {
-        let asc2, end2;
-        const result2 = [];
-        for (
-          _ = 0, end2 = n, asc2 = 0 <= end2;
-          asc2 ? _ < end2 : _ > end2;
-          asc2 ? _++ : _--
-        ) {
-          result2.push({});
-        }
-        return result2;
-      })(),
+      pi: Array.from({ length: n }, () => ({})),
 
       // same structure as optimal.m -- holds the overall metric.
-      g: (() => {
-        let asc3, end3;
-        const result3 = [];
-        for (
-          _ = 0, end3 = n, asc3 = 0 <= end3;
-          asc3 ? _ < end3 : _ > end3;
-          asc3 ? _++ : _--
-        ) {
-          result3.push({});
-        }
-        return result3;
-      })(),
+      g: Array.from({ length: n }, () => ({})),
     };
 
     // helper: considers whether a length-l sequence ending at match m is better (fewer guesses)
@@ -218,46 +156,32 @@ const scoring = {
     // helper: evaluate bruteforce matches ending at k.
     const bruteforce_update = (k) => {
       // see if a single bruteforce match spanning the k-prefix is optimal.
-      m = make_bruteforce_match(0, k);
+      let m = make_bruteforce_match(0, k);
       update(m, 1);
-      return (() => {
-        const result4 = [];
-        for (
-          var i = 1, end4 = k, asc4 = 1 <= end4;
-          asc4 ? i <= end4 : i >= end4;
-          asc4 ? i++ : i--
-        ) {
-          // generate k bruteforce matches, spanning from (i=1, j=k) up to (i=k, j=k).
-          // see if adding these new matches to any of the sequences in optimal[i-1]
-          // leads to new bests.
-          m = make_bruteforce_match(i, k);
-          result4.push(
-            (() => {
-              const result5 = [];
-              const object = optimal.m[i - 1];
-              for (let l in object) {
-                const last_m = object[l];
-                l = parseInt(l);
-                // corner: an optimal sequence will never have two adjacent bruteforce matches.
-                // it is strictly better to have a single bruteforce match spanning the same region:
-                // same contribution to the guess product with a lower length.
-                // --> safe to skip those cases.
-                if (last_m.pattern === 'bruteforce') {
-                  continue;
-                }
-                // try adding m to this length-l sequence.
-                result5.push(update(m, l + 1));
-              }
-              return result5;
-            })()
-          );
+      for (let i = 1; i <= k; i++) {
+        // generate k bruteforce matches, spanning from (i=1, j=k) up to (i=k, j=k).
+        // see if adding these new matches to any of the sequences in optimal[i-1]
+        // leads to new bests.
+        m = make_bruteforce_match(i, k);
+        const object = optimal.m[i - 1];
+        for (let l in object) {
+          const last_m = object[l];
+          const l_val = parseInt(l);
+          // corner: an optimal sequence will never have two adjacent bruteforce matches.
+          // it is strictly better to have a single bruteforce match spanning the same region:
+          // same contribution to the guess product with a lower length.
+          // --> safe to skip those cases.
+          if (last_m.pattern === 'bruteforce') {
+            continue;
+          }
+          // try adding m to this length-l sequence.
+          update(m, l_val + 1);
         }
-        return result4;
-      })();
+      }
     };
 
     // helper: make bruteforce match objects spanning i to j, inclusive.
-    var make_bruteforce_match = (i, j) => {
+    const make_bruteforce_match = (i, j) => {
       return {
         pattern: 'bruteforce',
         token: password.slice(i, +j + 1 || undefined),
@@ -283,7 +207,7 @@ const scoring = {
       }
 
       while (k >= 0) {
-        m = optimal.m[k][l];
+        const m = optimal.m[k][l];
         optimal_match_sequence.unshift(m);
         k = m.i - 1;
         l--;
@@ -291,12 +215,9 @@ const scoring = {
       return optimal_match_sequence;
     };
 
-    for (
-      k = 0, end4 = n, asc4 = 0 <= end4;
-      asc4 ? k < end4 : k > end4;
-      asc4 ? k++ : k--
-    ) {
-      for (m of Array.from(matches_by_j[k])) {
+    let guesses;
+    for (k = 0; k < n; k++) {
+      for (const m of Array.from(matches_by_j[k])) {
         if (m.i > 0) {
           for (let l in optimal.m[m.i - 1]) {
             l = parseInt(l);
@@ -414,14 +335,15 @@ const scoring = {
       return Math.pow(char_class_bases[match.regex_name], match.token.length);
     } else {
       switch (match.regex_name) {
-        case 'recent_year':
+        case 'recent_year': {
           // conservative estimate of year space: num years from REFERENCE_YEAR.
           // if year is close to REFERENCE_YEAR, estimate a year space of MIN_YEAR_SPACE.
-          var year_space = Math.abs(
-            parseInt(match.regex_match[0]) - this.REFERENCE_YEAR
+          const year_space = Math.max(
+            Math.abs(parseInt(match.regex_match[0]) - this.REFERENCE_YEAR),
+            this.MIN_YEAR_SPACE
           );
-          year_space = Math.max(year_space, this.MIN_YEAR_SPACE);
           return year_space;
+        }
       }
     }
   },
@@ -444,26 +366,11 @@ const scoring = {
   // slightly different for keypad/mac keypad, but close enough
   KEYPAD_AVERAGE_DEGREE: calc_average_degree(adjacency_graphs.keypad),
 
-  KEYBOARD_STARTING_POSITIONS: (() => {
-    const result = [];
-    for (k in adjacency_graphs.qwerty) {
-      v = adjacency_graphs.qwerty[k];
-      result.push(k);
-    }
-    return result;
-  })().length,
-  KEYPAD_STARTING_POSITIONS: (() => {
-    const result1 = [];
-    for (k in adjacency_graphs.keypad) {
-      v = adjacency_graphs.keypad[k];
-      result1.push(k);
-    }
-    return result1;
-  })().length,
+  KEYBOARD_STARTING_POSITIONS: Object.keys(adjacency_graphs.qwerty).length,
+  KEYPAD_STARTING_POSITIONS: Object.keys(adjacency_graphs.keypad).length,
 
   spatial_guesses(match) {
-    let d, i, s;
-    let asc, end;
+    let d, s;
     if (['qwerty', 'dvorak'].includes(match.graph)) {
       s = this.KEYBOARD_STARTING_POSITIONS;
       d = this.KEYBOARD_AVERAGE_DEGREE;
@@ -475,17 +382,9 @@ const scoring = {
     const L = match.token.length;
     const t = match.turns;
     // estimate the number of possible patterns w/ length L or less with t turns or less.
-    for (
-      i = 2, end = L, asc = 2 <= end;
-      asc ? i <= end : i >= end;
-      asc ? i++ : i--
-    ) {
+    for (let i = 2; i <= L; i++) {
       const possible_turns = Math.min(t, i - 1);
-      for (
-        let j = 1, end1 = possible_turns, asc1 = 1 <= end1;
-        asc1 ? j <= end1 : j >= end1;
-        asc1 ? j++ : j--
-      ) {
+      for (let j = 1; j <= possible_turns; j++) {
         guesses += this.nCk(i - 1, j - 1) * s * Math.pow(d, j);
       }
     }
@@ -497,13 +396,8 @@ const scoring = {
       if (S === 0 || U === 0) {
         guesses *= 2;
       } else {
-        let asc2, end2;
         let shifted_variations = 0;
-        for (
-          i = 1, end2 = Math.min(S, U), asc2 = 1 <= end2;
-          asc2 ? i <= end2 : i >= end2;
-          asc2 ? i++ : i--
-        ) {
+        for (let i = 1; i <= Math.min(S, U); i++) {
           shifted_variations += this.nCk(S + U, i);
         }
         guesses *= shifted_variations;
@@ -531,7 +425,6 @@ const scoring = {
   ALL_LOWER: /^[^A-Z]+$/,
 
   uppercase_variations(match) {
-    let chr;
     const word = match.token;
     if (word.match(this.ALL_LOWER) || word.toLowerCase() === word) {
       return 1;
@@ -547,63 +440,26 @@ const scoring = {
     // otherwise calculate the number of ways to capitalize U+L uppercase+lowercase letters
     // with U uppercase letters or less. or, if there's more uppercase than lower (for eg. PASSwORD),
     // the number of ways to lowercase U+L letters with L lowercase letters or less.
-    const U = (() => {
-      const result2 = [];
-      for (chr of Array.from(word.split(''))) {
-        if (chr.match(/[A-Z]/)) {
-          result2.push(chr);
-        }
-      }
-      return result2;
-    })().length;
-    const L = (() => {
-      const result3 = [];
-      for (chr of Array.from(word.split(''))) {
-        if (chr.match(/[a-z]/)) {
-          result3.push(chr);
-        }
-      }
-      return result3;
-    })().length;
+    const U = word.split('').filter((ch) => /[A-Z]/.test(ch)).length;
+    const L = word.split('').filter((ch) => /[a-z]/.test(ch)).length;
     let variations = 0;
-    for (
-      let i = 1, end = Math.min(U, L), asc = 1 <= end;
-      asc ? i <= end : i >= end;
-      asc ? i++ : i--
-    ) {
+    for (let i = 1; i <= Math.min(U, L); i++) {
       variations += this.nCk(U + L, i);
     }
     return variations;
   },
 
   l33t_variations(match) {
-    let chr;
     if (!match.l33t) {
       return 1;
     }
     let variations = 1;
-    for (var subbed in match.sub) {
+    for (const subbed of Object.keys(match.sub)) {
       // lower-case match.token before calculating: capitalization shouldn't affect l33t calc.
-      var unsubbed = match.sub[subbed];
-      var chrs = match.token.toLowerCase().split('');
-      const S = (() => {
-        const result2 = [];
-        for (chr of Array.from(chrs)) {
-          if (chr === subbed) {
-            result2.push(chr);
-          }
-        }
-        return result2;
-      })().length; // num of subbed chars
-      const U = (() => {
-        const result3 = [];
-        for (chr of Array.from(chrs)) {
-          if (chr === unsubbed) {
-            result3.push(chr);
-          }
-        }
-        return result3;
-      })().length; // num of unsubbed chars
+      const unsubbed = match.sub[subbed];
+      const chrs = match.token.toLowerCase().split('');
+      const S = chrs.filter((chr) => chr === subbed).length; // num of subbed chars
+      const U = chrs.filter((chr) => chr === unsubbed).length; // num of unsubbed chars
       if (S === 0 || U === 0) {
         // for this sub, password is either fully subbed (444) or fully unsubbed (aaa)
         // treat that as doubling the space (attacker needs to try fully subbed chars in addition to
@@ -614,11 +470,7 @@ const scoring = {
         // with aa44a, U = 3, S = 2, attacker needs to try unsubbed + one sub + two subs
         const p = Math.min(U, S);
         let possibilities = 0;
-        for (
-          let i = 1, end = p, asc = 1 <= end;
-          asc ? i <= end : i >= end;
-          asc ? i++ : i--
-        ) {
+        for (let i = 1; i <= p; i++) {
           possibilities += this.nCk(U + S, i);
         }
         variations *= possibilities;

--- a/src/time_estimates.ts
+++ b/src/time_estimates.ts
@@ -48,34 +48,31 @@ const time_estimates = {
     const month = day * 31;
     const year = month * 12;
     const century = year * 100;
-    let [display_num, display_str] = Array.from(
-      (() => {
-        let base;
-        if (seconds < 1) {
-          return [null, 'less than a second'];
-        } else if (seconds < minute) {
-          base = Math.round(seconds);
-          return [base, `${base} second`];
-        } else if (seconds < hour) {
-          base = Math.round(seconds / minute);
-          return [base, `${base} minute`];
-        } else if (seconds < day) {
-          base = Math.round(seconds / hour);
-          return [base, `${base} hour`];
-        } else if (seconds < month) {
-          base = Math.round(seconds / day);
-          return [base, `${base} day`];
-        } else if (seconds < year) {
-          base = Math.round(seconds / month);
-          return [base, `${base} month`];
-        } else if (seconds < century) {
-          base = Math.round(seconds / year);
-          return [base, `${base} year`];
-        } else {
-          return [null, 'centuries'];
-        }
-      })()
-    );
+    let display_num: number | null;
+    let display_str: string;
+    if (seconds < 1) {
+      [display_num, display_str] = [null, 'less than a second'];
+    } else if (seconds < minute) {
+      display_num = Math.round(seconds);
+      display_str = `${display_num} second`;
+    } else if (seconds < hour) {
+      display_num = Math.round(seconds / minute);
+      display_str = `${display_num} minute`;
+    } else if (seconds < day) {
+      display_num = Math.round(seconds / hour);
+      display_str = `${display_num} hour`;
+    } else if (seconds < month) {
+      display_num = Math.round(seconds / day);
+      display_str = `${display_num} day`;
+    } else if (seconds < year) {
+      display_num = Math.round(seconds / month);
+      display_str = `${display_num} month`;
+    } else if (seconds < century) {
+      display_num = Math.round(seconds / year);
+      display_str = `${display_num} year`;
+    } else {
+      [display_num, display_str] = [null, 'centuries'];
+    }
     if (display_num != null && display_num !== 1) {
       display_str += 's';
     }


### PR DESCRIPTION
Cleans up leftover patterns from the CoffeeScript → JS/TS decaffeination:

**File-top / hoisted variables**
- `matching.js`: removed `let name`; use `for (const name of Object.keys(frequency_lists))`
- `scoring.js`: removed `let k, v`; use `Object.keys(graph).length` and `Object.keys(adjacency_graphs.*).length`

**IIFE replacements**
- `empty(obj)` → `Object.keys(obj).length === 0`
- `calc_average_degree`, KEYBOARD/KEYPAD_STARTING_POSITIONS → `Object.keys(...).length`
- `matches_by_j`, `optimal.m/pi/g` → `Array.from({ length: n }, () => [])` or `() => ({})`
- U/L counts in uppercase_variations and l33t_variations → `.filter(...).length`
- `match.sub_display` → `Object.entries(match_sub).map(...).join(', ')`
- `feedback.ts`: dictionary warning IIFE → `let warning` + switch with break
- `time_estimates.ts`: `display_time` IIFE → if/else chain

**CoffeeScript-style for loops**
- Replaced `for (let i = start, end = n, asc = ...; asc ? i <= end : ...; asc ? i++ : i--)` with standard `for (let i = start; i <= end; i++)` (and `i < end` where appropriate) in matching.js and scoring.js.

**var → let/const**
- Replaced remaining `var` with `let` or `const` in matching.js, scoring.js, and feedback.ts.
- Fixed duplicate `let shifted_count` in spatial_match_helper.

All tests pass (Jest + packaging).

Made with [Cursor](https://cursor.com)