### PR TITLE
fix: address TypeScript 6 compatibility issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "semantic-release": "25.0.3",
         "tsup": "8.5.1",
         "tsx": "4.21.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.2",
         "vitepress": "1.6.4",
         "vitest": "4.1.0"
       }
@@ -9902,9 +9902,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "semantic-release": "25.0.3",
     "tsup": "8.5.1",
     "tsx": "4.21.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.2",
     "vitepress": "1.6.4"
   },
   "overrides": {

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -55,7 +55,7 @@ const feedback = {
   get_match_feedback(
     match: Match,
     is_sole_match: boolean
-  ): { warning: Warning; suggestions: string[] } {
+  ): Feedback | null {
     switch (match.pattern) {
       case 'dictionary':
         return feedback.get_dictionary_match_feedback(match, is_sole_match);
@@ -94,7 +94,7 @@ const feedback = {
             ],
           };
         }
-        break;
+        return null;
 
       case 'date':
         return {
@@ -102,12 +102,13 @@ const feedback = {
           suggestions: ['Avoid dates and years that are associated with you'],
         };
     }
+    return null;
   },
 
   get_dictionary_match_feedback(
     match: DictionaryMatch,
     is_sole_match: boolean
-  ): { warning: Warning; suggestions: string[] } {
+  ): Feedback {
     let warning: Warning | null = null;
     switch (match.dictionary_name) {
       case 'passwords':

--- a/src/matching.ts
+++ b/src/matching.ts
@@ -107,7 +107,7 @@ const matching = {
   mod(n: number, m: number): number {
     return ((n % m) + m) % m;
   },
-  sorted(matches: Match[]): Match[] {
+  sorted<T extends Match>(matches: T[]): T[] {
     return matches.sort((m1, m2) => m1.i - m2.i || m1.j - m2.j);
   },
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
     "target": "es5",
     "lib": ["ES2019", "dom"],
     "rootDir": "src",


### PR DESCRIPTION
### Motivation
- Dependabot upgraded TypeScript to 6.0 and the project hit new typecheck and deprecation errors due to the `target: "es5"` deprecation and stricter assignability/return checks.
- Small typing mismatches caused by stricter inference (non-nullable returns and array subtype preservation) needed fixes to restore a clean `tsc` run without changing runtime behavior.

### Description
- Added `"ignoreDeprecations": "6.0"` to `tsconfig.json` to silence the deprecated `target: "es5"` warning under TypeScript 6 while keeping current build outputs.  
- Updated `get_match_feedback` in `src/feedback.ts` to return `Feedback | null` and added explicit `null` returns for fallthrough/unsupported regex cases so the function's type matches possible runtime values.  
- Kept `get_dictionary_match_feedback` return type as `Feedback` and ensured callers handle `null` where appropriate.  
- Made `matching.sorted` generic (`sorted<T extends Match>(matches: T[]): T[]`) in `src/matching.ts` so sorting preserves concrete subtype arrays (fixing assignability to `DictionaryMatch[]`, `RegexMatch[]`, `DateMatch[]`, etc.).

### Testing
- Ran `npm run typecheck` and TypeScript compilation completed successfully.  
- Ran unit tests with `npm test` and all tests passed.  
- Ran packaging checks with `npm run test:packaging` (build, bundle checks, and packaging consumer tests) and the packaging suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c284c090988328804ba533077b7509)